### PR TITLE
Fixed typographical error, changed Ceasar to Caesar in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Thanks to all [contributors](https://github.com/ruby-vietnam/awesome-web-fronten
 
 ## eBooks
 
-* [Styling with SASS by Julio Ceasar](http://http://juliocesar.github.io/styling-with-sass)
+* [Styling with SASS by Julio Caesar](http://http://juliocesar.github.io/styling-with-sass)
 
 ## Tutorials
 


### PR DESCRIPTION
ruby-vietnam, I've corrected a typographical error in the documentation of the [awesome-web-frontend](https://github.com/ruby-vietnam/awesome-web-frontend) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
